### PR TITLE
Fix muckled? function.

### DIFF
--- a/lich.rb
+++ b/lich.rb
@@ -4624,12 +4624,12 @@ def checkreallybleeding
 end
 
 def muckled?
-   muckled = checkwebbed or checkdead or checkstunned
+   muckled = checkwebbed || checkdead || checkstunned
    if defined?(checksleeping)
-      muckled = muckled or checksleeping
+      muckled = muckled || checksleeping
    end
    if defined?(checkbound)
-      muckled = muckled or checkbound
+      muckled = muckled || checkbound
    end
    return muckled
 end


### PR DESCRIPTION
The muckled? function uses 'or' instead  of '||'. 'or' has lower precedence than '=', so the entire thing is really just a checkwebbed function. This uses the correct logic to make muckled? work.