### PR TITLE
Fix $infomon_bound for typo update

### DIFF
--- a/scripts/infomon.lic
+++ b/scripts/infomon.lic
@@ -1441,7 +1441,7 @@ while line = get
 			$infomon_sleeping = true
 		elsif line =~ /^Your thoughts slowly come back to you as you find yourself lying on the ground\.  You must have been sleeping\.$|^You wake up from your slumber\.$|^You are awoken|^You awake/
 			$infomon_sleeping = false
-		elsif line == 'An unseen force envelopes you, restricting all movement.'
+		elsif line == 'An unseen force envelops you, restricting all movement.'
 			$infomon_bound = true
 		elsif line =~ /^The restricting force that envelops you dissolves away\.|^You shake off the immobilization that was restricting your movements!/
 			$infomon_bound = false


### PR DESCRIPTION
The messaging for bind was updated to correct a typo. It was "An unseen force envelopes you, restricting all movement." Envelopes isn't the right word - it was updated to 'envelops'. This fix makes $infomon_bound work again.